### PR TITLE
Add option to disable debug view

### DIFF
--- a/Packages/com.alexmalyutindev.radiance-cascades-urp/Core/RadianceCascadesFeature.cs
+++ b/Packages/com.alexmalyutindev.radiance-cascades-urp/Core/RadianceCascadesFeature.cs
@@ -6,6 +6,7 @@ public class RadianceCascadesFeature : ScriptableRendererFeature
     public Material BlitMaterial;
     public ComputeShader RadianceCascades;
     public ComputeShader RadianceCascades3d;
+    public bool showDebugView;
 
     [SerializeField]
     private RenderType _renderType;
@@ -15,7 +16,7 @@ public class RadianceCascadesFeature : ScriptableRendererFeature
 
     public override void Create()
     {
-        _pass = new RadianceCascadesPass(RadianceCascades, RadianceCascades3d, BlitMaterial)
+        _pass = new RadianceCascadesPass(RadianceCascades, RadianceCascades3d, BlitMaterial, showDebugView)
         {
             renderPassEvent = RenderPassEvent.AfterRenderingDeferredLights
         };

--- a/Packages/com.alexmalyutindev.radiance-cascades-urp/Core/RadianceCascadesPass.cs
+++ b/Packages/com.alexmalyutindev.radiance-cascades-urp/Core/RadianceCascadesPass.cs
@@ -17,6 +17,8 @@ public class RadianceCascadesPass : ScriptableRenderPass
     private readonly RadianceCascadeCompute _compute;
     private readonly int _renderCascadeKernel;
 
+    private bool _showDebugPreview = true;
+
 
     // High:
     // Using aspect 7/4(14/8) to be closer to 16/9.
@@ -33,7 +35,7 @@ public class RadianceCascadesPass : ScriptableRenderPass
         new(32 * 3, 32 * 2), // 48x32 probes0
     };
 
-    public RadianceCascadesPass(ComputeShader radianceCascadesCs, ComputeShader radianceCascades3d, Material blit)
+    public RadianceCascadesPass(ComputeShader radianceCascadesCs, ComputeShader radianceCascades3d, Material blit, bool showDebugView)
     {
         _profilingSampler = new ProfilingSampler(nameof(RadianceCascadesPass));
         _radianceCascadesCs = radianceCascadesCs;
@@ -43,6 +45,8 @@ public class RadianceCascadesPass : ScriptableRenderPass
         _blit = blit;
         _renderCascadeKernel = _radianceCascadesCs.FindKernel("RenderCascade");
         // ConfigureInput(ScriptableRenderPassInput.Depth | ScriptableRenderPassInput.Color);
+
+        _showDebugPreview = showDebugView;
     }
 
     public override void Configure(CommandBuffer cmd, RenderTextureDescriptor cameraTextureDescriptor)
@@ -170,6 +174,7 @@ public class RadianceCascadesPass : ScriptableRenderPass
 
     private void PreviewCascades(CommandBuffer cmd, RTHandle[] rtHandles, float offset = 0.0f)
     {
+        if (!_showDebugPreview) { return; }
         cmd.BeginSample("Preview");
 
         const float scale = 1f / 8f;


### PR DESCRIPTION
I wanted to see without the debug view in the way.

Demo: 

https://github.com/user-attachments/assets/ca830b91-4fe8-452a-9d1e-5d49f06ebc57

By the way, love this project! I tested it on Unity 6 with HDR on as well, and it seems to work with just a few tweeks in the project settings.